### PR TITLE
Do not update glibc version automatically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,19 +5,6 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
-  "regexManagers": [
-    {
-      "fileMatch": [
-        "^Dockerfile$"
-      ],
-      "matchStrings": [
-        "ARG GLIBC_VERSION=(?<currentValue>.*)"
-      ],
-      "datasourceTemplate": "github-tags",
-      "depNameTemplate": "sgerrand/alpine-pkg-glibc",
-      "versioningTemplate": "loose"
-    }
-  ],
   "packageRules": [
     {
       "matchPackagePatterns": ["^grpc-tools"],


### PR DESCRIPTION
Specific version of glibc is required by the ruby gem and can't be independently updated.