### PR TITLE
Revert "Update dependency grpcio_tools to v1.74.0 (#52)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-grpcio_tools==1.74.0
+grpcio_tools==1.62.2


### PR DESCRIPTION
This reverts commit 5cda67ced06f11c3d8823aabd484b94874a292b9.

The newer version of grpcio_tools generates python scripts that include runtime version validation.

However, py3-protobuf for Alpine 3.20 does not support this feature.

Therefore, to maintain compatibility, it's better to roll back grpcio_tool for now.